### PR TITLE
Fix $in queries

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -59,6 +59,11 @@ class Table {
         continue;
       }
 
+      if (k === '$in') {
+        conditions.push(`"${column}" IN (${PG.as.csv(value[k])})`);
+        continue;
+      }
+
       if (k === '$gt') {
         operator = '>';
         plain = false;
@@ -80,10 +85,6 @@ class Table {
         plain = false;
       }
       else if (k === '$eq') {
-        plain = false;
-      }
-      else if (k === '$in') {
-        operator = 'IN';
         plain = false;
       }
       else if (k === '$like') {

--- a/test/index.js
+++ b/test/index.js
@@ -350,7 +350,7 @@ describe('find', () => {
       return db.users.find({ pets: { $in: [1, 2, 3] } });
     }).then((query) => {
 
-      expect(query).to.equal('SELECT * FROM "users" WHERE "pets" IN array[1,2,3]');
+      expect(query).to.equal('SELECT * FROM "users" WHERE "pets" IN (1,2,3)');
       done();
     }).catch(done);
   });


### PR DESCRIPTION
WHERE ... IN doesn't work with `IN array[values...]`, which is what
the default interpolation of a js array gives us, it requires
`IN (values...)`.

Only thing I'm unsure of is the injection impact of this?