### PR TITLE
Add transaction support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,6 +151,22 @@ class Muckraker {
 
     return this._db.query.apply(this._db, arguments);
   }
+
+  tx(fn) {
+
+    return this._db.tx((t) => {
+
+      const mr = Object.create(this);
+      mr._db = t;
+
+      for (const table of this._tables) {
+        mr[table] = Object.create(this[table]);
+        mr[table]._db = t;
+      }
+
+      return fn(mr);
+    });
+  }
 }
 
 module.exports = Muckraker;

--- a/test/index.js
+++ b/test/index.js
@@ -582,3 +582,18 @@ describe('routines', () => {
     done();
   });
 });
+
+describe('transactions', () => {
+
+  it('can run a transaction', (done) => {
+
+    const db = new Muckraker(internals);
+    db.tx((t) => {
+
+      const query = db.query('SELECT * FROM "users"');
+      expect(query).to.equal('SELECT * FROM "users"');
+      done();
+    });
+  });
+
+});

--- a/test/mock.js
+++ b/test/mock.js
@@ -79,6 +79,11 @@ class MockPG {
       }
     });
   }
+
+  tx(fn) {
+
+    return fn(this);
+  }
 }
 
 module.exports = MockPG;


### PR DESCRIPTION
Not really sure how to test this properly with everything mocked, so the coverage is there but it's not _really_ testing anything. But does look to be working in a simple end-to-end test for me.

Realised that we can support transactions fairly simply, by "inheriting" muckraker and it's tables, and overriding `this._db` with the transaction.