### PR TITLE
Correcting manual use of QueryFile

### DIFF
--- a/test/mock.js
+++ b/test/mock.js
@@ -9,13 +9,6 @@ class MockPG {
   }
 
   query(q, p) {
-    if(q instanceof PG.QueryFile) {
-      q.prepare();
-      if(q.error) {
-        throw q.error;
-      }
-      q = q.query;
-    }
     return PG.as.format(q, p);
   }
 

--- a/test/mock.js
+++ b/test/mock.js
@@ -10,6 +10,7 @@ class MockPG {
 
   query(q, p) {
     if(q instanceof PG.QueryFile) {
+      q.prepare();
       if(q.error) {
         throw q.error;
       }

--- a/test/mock.js
+++ b/test/mock.js
@@ -9,8 +9,13 @@ class MockPG {
   }
 
   query(q, p) {
-
-    return PG.as.format(q instanceof PG.QueryFile ? q.query : q, p);
+    if(q instanceof PG.QueryFile) {
+      if(q.error) {
+        throw q.error;
+      }
+      q = q.query;
+    }
+    return PG.as.format(q, p);
   }
 
   any(q, p) {


### PR DESCRIPTION
Correcting the manual use of `QueryFile`, to make it consistent with how the type is used inside `pg-promise`.

Note: property `.query` is for the library's internal use, but since you are using it here anyway, this is how to do it correctly.