### PR TITLE
feat(transactions): allow for transaction mode parameter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,6 +74,7 @@ class Muckraker {
     options = Object.assign({}, { encrypt: {}, cipher: 'aes256' }, options);
     this._pg = PG(options.pg);
     this.end = this._pg.end.bind(this._pg);
+    this.txMode = this._pg.txMode;
     // Our tests are all mocked so we should skip coverage here
     // $lab:coverage:off$
     this._db = options._mocked || this._pg(options.connection);
@@ -152,9 +153,13 @@ class Muckraker {
     return this._db.query.apply(this._db, arguments);
   }
 
-  tx(fn) {
+  tx(opts, fn) {
 
-    return this._db.tx((t) => {
+    if (!fn) {
+      fn = opts;
+      opts = {};
+    }
+    return this._db.tx(opts, (t) => {
 
       const mr = Object.create(this);
       mr._db = t;

--- a/test/index.js
+++ b/test/index.js
@@ -520,12 +520,31 @@ describe('routines', () => {
 
 describe('transactions', () => {
 
+  it('txMode exists', () => {
+
+    const db = new Muckraker(internals);
+    expect(db.txMode).to.exist();
+  });
+
   it('can run a transaction', () => {
 
     const db = new Muckraker(internals);
     return db.tx((t) => {
 
-      const query = db.query('SELECT * FROM "users"');
+      expect(t._db._txopts).to.equal({});
+      const query = t.query('SELECT * FROM "users"');
+      expect(query).to.equal('SELECT * FROM "users"');
+    });
+  });
+
+  it('can run a transaction with options', () => {
+
+    const db = new Muckraker(internals);
+    const opts = { test: true };
+    return db.tx(opts, (t) => {
+
+      expect(t._db._txopts).to.equal(opts);
+      const query = t.query('SELECT * FROM "users"');
       expect(query).to.equal('SELECT * FROM "users"');
     });
   });

--- a/test/mock.js
+++ b/test/mock.js
@@ -80,8 +80,9 @@ class MockPG {
     });
   }
 
-  tx(fn) {
+  tx(opts, fn) {
 
+    this._txopts = opts; //Set so we can find it in tests
     return fn(this);
   }
 }


### PR DESCRIPTION
Adds an optional param that gets passed through to pg-promise for transactions.
Exposes pg-promises txMode namespace for easier generation of that param